### PR TITLE
Fix how parameters are passed to Chocolatey Office 365 install

### DIFF
--- a/vm_setup_scripts/windows_server/install-tools.ps1
+++ b/vm_setup_scripts/windows_server/install-tools.ps1
@@ -16,7 +16,7 @@ if (-not $testchoco) {
 }
 
 #Install Microsoft Office with Chocolatey
-choco install office365business /exclude:"Access Groove Lync OneDrive OneNote Outlook Publisher Excel PowerPoint Teams" -y;
+choco install office365business --params='/exclude:"Access Groove Lync OneDrive OneNote Outlook Publisher Excel PowerPoint Teams"' -y;
 Write-Host "[+] Installed Microsoft Office";
 
 #Install 7-Zip Command Line tools with Chocolatey


### PR DESCRIPTION
In the current install-tools.ps1 script, the call to Chocolatey to
install Office 365 applications doesn't seem to correctly parse the list
of Office 365 applications to exclude. See the output below.

```
Installing the following packages:
office365business;/exclude:Access Groove Lync OneDrive OneNote Outlook Publisher Excel PowerPoint Teams
By installing, you accept licenses for the packages.
Progress: Downloading Office365Business 14729.20228... 100%

Office365Business v14729.20228 [Approved]
office365business package files install completed. Performing other installation steps.
No custom configuration specified. Generating one...
No Product ID specified, using default: O365BusinessRetail
No excluded apps specified, installing all
No Language ID specified, using default: MatchOS
No updates value specified, using default: TRUE
No updates value specified, using default: TRUE
```

The fix in this commit, based on official Chocolatey documentation,
seems to address the issue given the output below.

```
Installing the following packages:
office365business
By installing, you accept licenses for the packages.
Progress: Downloading Office365Business 14729.20228... 100%

Office365Business v14729.20228 [Approved]
office365business package files install completed. Performing other installation steps.
No custom configuration specified. Generating one...
No Product ID specified, using default: O365BusinessRetail
The following apps will not be installed: Access Groove Lync OneDrive OneNote Outlook Publisher Excel PowerPoint Teams
No Language ID specified, using default: MatchOS
No updates value specified, using default: TRUE
No updates value specified, using default: TRUE
```