### PR TITLE
Grant Kali attacker user passwordless sudo access

### DIFF
--- a/vm_setup_scripts/kali/configure-attacker-user.sh
+++ b/vm_setup_scripts/kali/configure-attacker-user.sh
@@ -6,5 +6,5 @@ else
     useradd -m -s /bin/bash attacker
     echo "attacker:ATT&CK" | chpasswd
 fi
-usermod -a attacker -G sudo
+usermod -a attacker -G kali-trusted
 echo "[i] attacker user configured"


### PR DESCRIPTION
Per `/etc/sudoers.d/kali-grant-root`, adding the `attacker` user to the
`kali-trusted` group instead of the `sudo` group will grant the user
passwordless access to any command.

fixes #37