### PR TITLE
Registry setup change

### DIFF
--- a/vm_setup_scripts/windows_server/setup-dc.ps1
+++ b/vm_setup_scripts/windows_server/setup-dc.ps1
@@ -19,7 +19,7 @@ if ($env:COMPUTERNAME -ne "targetDC") {
     $password = Read-Host "Login Password";
     Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name 'DefaultUserName' -Type String -Value "Administrator";
     Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name 'DefaultPassword' -Type String -Value $password;
-    New-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name 'AutoAdminLogon' -Type String -Value "1";
+    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name 'AutoAdminLogon' -Type String -Value "1";
 
     #Replace username and userID placeholders in Scheduled Task XML file with local values
     $sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value;


### PR DESCRIPTION
If the registry key `AutoAdminLogon` already exists, using `New-ItemProperty` results in an error and premature termination of the script. 

Changing `New-ItemProperty` to `Set-ItemProperty` will create the key if it doesn't exist, or update the value of the key if it already exists.

![Screenshot 2022-07-29 153348](https://user-images.githubusercontent.com/81784737/181854027-8d9d1f18-1946-42d2-97f3-d3bed37e88bd.png)

