### PR TITLE
Create disable-defender-ec2.ps1

### DIFF
--- a/vm_setup_scripts/windows_server/disable-defender-ec2.ps1
+++ b/vm_setup_scripts/windows_server/disable-defender-ec2.ps1
@@ -1,0 +1,30 @@
+#Author: Christian Galvan
+#Description: Disable windows defender, cloudbased protectection and all AV protections for the purpose of Adversary Operations Course on Windows Server 2019 Fullbase in AWS
+#Check AV definition updates Source: https://theitbros.com/managing-windows-defender-using-powershell/
+
+Get-MpComputerStatus | Select-Object -Property Antivirusenabled,AMServiceEnabled,AntispywareEnabled,BehaviorMonitorEnabled,IoavProtectionEnabled,NISEnabled,OnAccessProtectionEnabled,RealTimeProtectionEnabled,IsTamperProtected,AntivirusSignatureLastUpdated
+
+Set-MpPreference -DisableRealtimeMonitoring $true
+Set-MpPreference -MAPSReporting 0
+#get status on tamper protection​
+Get-MpComputerStatus | select IsTamperProtected
+#disable Microsoft Defender real-time protection with PowerShell
+Set-MpPreference -DisableRealtimeMonitoring $true
+#stop the real-time protection and run the following command in the elevated PowerShell session
+Uninstall-WindowsFeature -Name Windows-Defender
+#You can disable archive files scanning using the command:
+Set-MpPreference -DisableArchiveScanning $True
+#check status of archive scanning
+Get-MpPreference|select DisableArchiveScanning
+#disable cloud based protection
+Set-MpPreference -MAPSReporting 0
+​
+
+#check all security definitions again
+Get-MpComputerStatus | Select-Object -Property Antivirusenabled,AMServiceEnabled,AntispywareEnabled,BehaviorMonitorEnabled,IoavProtectionEnabled,NISEnabled,OnAccessProtectionEnabled,RealTimeProtectionEnabled,IsTamperProtected,AntivirusSignatureLastUpdated
+
+#remove active threat using microsoft defender
+Defender\Remove-MpThreat
+
+Write-Host "Restart your server in order to remove all virus protection for this course" -ForegroundColor Green
+Write-Host "You can use the shutdown /r command to do it via CMD" -ForegroundColor Green


### PR DESCRIPTION
The setup-dc.ps1 file errors out because there is no "disable-defender.ps1" file in the vm_setup_scripts when following the instructions from the Cybrary Lab 1.8 instructions after running `git clone https://github.com/maddev-engenuity/AdversaryEmulation.git` 

With these 30 lines of powershell code, this script is able to uninstall all of the virus and threat protection on a Windows 2019 EC2 Base AMI after doing a restart of the server. 